### PR TITLE
Update LifeSpanHandler.CS

### DIFF
--- a/src/Handlers/LifeSpanHandler.cs
+++ b/src/Handlers/LifeSpanHandler.cs
@@ -149,12 +149,20 @@ namespace SharpBrowser {
 		//     value indicates whether the new browser window should be scriptable and in
 		//     the same process as the source browser.
 		public bool OnBeforePopup(IWebBrowser browserControl, IBrowser browser, IFrame frame, string targetUrl, string targetFrameName, WindowOpenDisposition targetDisposition, bool userGesture, IPopupFeatures popupFeatures, IWindowInfo windowInfo, IBrowserSettings browserSettings, ref bool noJavascriptAccess, out IWebBrowser newBrowser) {
+                     
+			if (targetUrl.Contains("google") ) //This will ensure that 'Sign in or Sign up with Google Popups open in CefSharp Default' because the method in the else block, failed to help users login through Google in sites like KhanAcademy.
+            {
+	    // Open in CefSharp Default
+                newBrowser = null;
+                return false;
+            }
+            else{
+	    // Open in new tab
+                newBrowser = myForm.AddNewBrowserTab(targetUrl);
 
-			// open popup in new tab!
-			newBrowser = myForm.AddNewBrowserTab(targetUrl);
-
-			return true;
-
+                return true;
+                
+            }
 		}
     }
 }


### PR DESCRIPTION
I added a condition, which will ensure that if the popup is a 'Sign In or Sign Up with Google' window, it will use CEFSharp Default popup. I noticed that the myForm.AddNewBrowserTab method will not help users to sign in with google. Therefore I used if and else statements to use Default CefSharp popup only if the popup's url has mention of google.