### PR TITLE
FAicons  Color Fix For Disabled

### DIFF
--- a/src/Controls/DrawingExt.cs
+++ b/src/Controls/DrawingExt.cs
@@ -252,5 +252,46 @@ namespace System.Drawing
         }
     }
 
+    public static class ColorExt 
+    {
+        /// <summary>
+        /// Creates color with corrected brightness.
+        /// </summary>
+        /// <param name="color">Color to correct.</param>
+        /// <param name="correctionFactor">The brightness correction factor. Must be between -1 and 1. 
+        /// Negative values produce darker colors.</param>
+        /// <returns>
+        /// Corrected <see cref="Color"/> structure.
+        /// </returns>
+        public static Color ChangeColorBrightness(this Color color, float correctionFactor)
+        {
+            correctionFactor = Math.Clamp(correctionFactor,-1,1);
+
+            float red = (float)color.R;
+            float green = (float)color.G;
+            float blue = (float)color.B;
+
+            if (correctionFactor < 0)
+            {
+                correctionFactor = 1 + correctionFactor;
+                red *= correctionFactor;
+                green *= correctionFactor;
+                blue *= correctionFactor;
+            }
+            else
+            {
+                red = (255 - red) * correctionFactor + red;
+                green = (255 - green) * correctionFactor + green;
+                blue = (255 - blue) * correctionFactor + blue;
+            }
+
+            return Color.FromArgb(color.A, (int)red, (int)green, (int)blue);
+        }
+
+        public static Color ChangeColorBrightness(this Color color, double correctionFactor)
+            => ChangeColorBrightness(color, (float)correctionFactor);
+
+
+    }
 
 }

--- a/src/MainForm.cs
+++ b/src/MainForm.cs
@@ -50,6 +50,7 @@ namespace SharpBrowser {
 			InitTooltips(this.Controls);
 			InitHotkeys();
 
+			InitFAButton_DisabledColors();
 			TxtURL.MakeTextbox_CustomBorderColor();
 
 			//cant  do this on gui. paneltoolbar gets deleted. buggy designer 
@@ -67,14 +68,33 @@ namespace SharpBrowser {
 
 		}
 
+        private void InitFAButton_DisabledColors()
+        {
+            BtnBack.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+            BtnForward.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+            BtnStop.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+            BtnRefresh.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+            BtnDownloads.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+            BtnHome.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+            BtnMenu.EnabledChanged += (s1, e1) => handleFAButton_DisabledColors(s1);
+        }
+        private async void handleFAButton_DisabledColors(object senderBtn)
+        {
+            var faBtn = senderBtn as FontAwesome.Sharp.IconButton;
+			//faBtn.IconColor = faBtn.Enabled ? Color.Black : PanelToolbar.BackColor.ChangeColorBrightness(0);
+			faBtn.IconColor = faBtn.Enabled ? Color.Black : Color.Black.ChangeColorBrightness(0.8);
 
-		#region App Icon
 
-		/// <summary>
-		/// embedding the resource using the Visual Studio designer results in a blurry icon.
-		/// the best way to get a non-blurry icon for Windows 7 apps.
-		/// </summary>
-		private void InitAppIcon() {
+        }
+
+
+        #region App Icon
+
+        /// <summary>
+        /// embedding the resource using the Visual Studio designer results in a blurry icon.
+        /// the best way to get a non-blurry icon for Windows 7 apps.
+        /// </summary>
+        private void InitAppIcon() {
 			assembly = Assembly.GetAssembly(typeof(MainForm));
 			Icon = new Icon(GetResourceStream("sharpbrowser.ico"), new Size(64, 64));
 		}


### PR DESCRIPTION
fix applied photo:

![image](https://github.com/user-attachments/assets/0f36a02e-1047-42e9-b908-ce73cb778424)

fa iconbutton disabled color is not faded as Edge/Chrome

so here is the fix.  

